### PR TITLE
ci: :construction_worker: basic CI workflows, like building the website

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: ci
+      include: scope
+    assignees:
+      - "lwjohnst86"

--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -1,0 +1,24 @@
+name: Auto-assign PR creator
+
+on:
+  pull_request:
+    types:
+      - reopened
+      - opened
+
+jobs:
+  auto-assign:
+    name: Auto-assign PR creator
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Assign PR to creator
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          gh pr edit $PR --add-assignee $AUTHOR --repo $REPO
+        env:
+          REPO: ${{ github.repository }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -1,0 +1,12 @@
+name: Build website
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-deploy-docs:
+    uses: seedcase-project/.github/.github/workflows/reusable-build-docs.yml@main
+    secrets:
+      netlify-token: ${{ secrets.NETLIFY_AUTH_TOKEN }}


### PR DESCRIPTION
Adds:

- Dependabot, which makes sure any workflows we have are up to date.
- Auto-assign PRs, so that the person who made a PR is assigned to it. This makes it easier to track things on the project board.
- Build the website, which will setup Quarto, build the website, and publish to Netlify. (this won't work yet, since the repo isn't a Quarto project yet).

Closes #14